### PR TITLE
Fixed html files not found error

### DIFF
--- a/backend/app/email-templates/html/booking_confirmation.html
+++ b/backend/app/email-templates/html/booking_confirmation.html
@@ -1,0 +1,113 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Booking Confirmed - {{ project_name }}</title>
+
+    <!-- Preview text for Gmail/Outlook -->
+    <meta name="description" content="Your taxi ride has been confirmed. View your booking details." />
+    <style>
+      body {
+        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+        background: #f9fafb;
+        padding: 2rem;
+        color: #1f2937;
+      }
+      .container {
+        background: #ffffff;
+        padding: 2rem;
+        max-width: 600px;
+        margin: 0 auto;
+        border-radius: 12px;
+        box-shadow: 0 8px 20px rgba(0, 0, 0, 0.05);
+        border-top: 5px solid #facc15;
+      }
+      .logo {
+        text-align: center;
+        margin-bottom: 1.5rem;
+      }
+      .logo img {
+        max-height: 50px;
+      }
+      h1 {
+        color: #111827;
+        font-size: 24px;
+        margin-top: 0;
+        text-align: center;
+      }
+      .summary {
+        margin-top: 1.5rem;
+        line-height: 1.7;
+        font-size: 15px;
+      }
+      .summary p {
+        margin: 0.4rem 0;
+      }
+      .highlight {
+        background: #fefce8;
+        padding: 1rem;
+        border: 1px solid #fde68a;
+        border-radius: 8px;
+        margin-top: 1rem;
+      }
+      .cta {
+        margin-top: 2rem;
+        text-align: center;
+      }
+      .cta a {
+        background-color: #facc15;
+        color: #1f2937;
+        text-decoration: none;
+        padding: 0.75rem 1.5rem;
+        border-radius: 6px;
+        font-weight: 600;
+        display: inline-block;
+      }
+      .cta a:hover {
+        background-color: #eab308;
+      }
+      .footer {
+        margin-top: 2rem;
+        font-size: 13px;
+        color: #6b7280;
+        text-align: center;
+      }
+    </style>
+  </head>
+  <body>
+    <div class="container">
+      <!-- Logo -->
+      <!-- <div class="logo">
+        <img src="https://yourdomain.com/logo.png" alt="{{ project_name }} Logo" />
+      </div> -->
+
+      <!-- Heading -->
+      <h1>🚕 Booking Confirmed</h1>
+      <p style="text-align: center;">Thank you for choosing <strong>{{ project_name }}</strong>.</p>
+
+      <!-- Booking Summary -->
+      <div class="highlight">
+        {% if booking_id %}
+        <p><strong>Booking ID:</strong> #{{ booking_id }}</p>
+        {% endif %}
+        <p><strong>Pickup:</strong> {{ pickup }}</p>
+        <p><strong>Destination:</strong> {{ destination }}</p>
+        <p><strong>Date:</strong> {{ date }}</p>
+        <p><strong>Time:</strong> {{ time }}</p>
+        <p><strong>Vehicle:</strong> {{ vehicle }}</p>
+        <p><strong>Total Fare:</strong> {{ fare }}<strong>€</strong></p>
+      </div>
+
+      <!-- CTA Button -->
+      <!-- <div class="cta">
+        <a href="{{ frontend_host }}/booking/success" target="_blank">View Booking</a>
+      </div> -->
+
+      <!-- Footer -->
+      <div class="footer">
+        You’ll receive another message when your driver is on the way.<br />
+        Need help? Reply to this email or contact our support team.
+      </div>
+    </div>
+  </body>
+</html>

--- a/backend/app/email-templates/html/new_account.html
+++ b/backend/app/email-templates/html/new_account.html
@@ -1,0 +1,178 @@
+<!doctype html>
+<html xmlns="http://www.w3.org/1999/xhtml" xmlns:v="urn:schemas-microsoft-com:vml"
+    xmlns:o="urn:schemas-microsoft-com:office:office">
+
+<head>
+    <title></title><!--[if !mso]><!-- -->
+    <meta http-equiv="X-UA-Compatible" content="IE=edge"><!--<![endif]-->
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+    <meta name="viewport" content="width=device-width,initial-scale=1">
+    <style type="text/css">
+        #outlook a {
+            padding: 0;
+        }
+
+        .ReadMsgBody {
+            width: 100%;
+        }
+
+        .ExternalClass {
+            width: 100%;
+        }
+
+        .ExternalClass * {
+            line-height: 100%;
+        }
+
+        body {
+            margin: 0;
+            padding: 0;
+            -webkit-text-size-adjust: 100%;
+            -ms-text-size-adjust: 100%;
+        }
+
+        table,
+        td {
+            border-collapse: collapse;
+            mso-table-lspace: 0pt;
+            mso-table-rspace: 0pt;
+        }
+
+        img {
+            border: 0;
+            height: auto;
+            line-height: 100%;
+            outline: none;
+            text-decoration: none;
+            -ms-interpolation-mode: bicubic;
+        }
+
+        p {
+            display: block;
+            margin: 13px 0;
+        }
+    </style><!--[if !mso]><!-->
+    <style type="text/css">
+        @media only screen and (max-width:480px) {
+            @-ms-viewport {
+                width: 320px;
+            }
+
+            @viewport {
+                width: 320px;
+            }
+        }
+    </style><!--<![endif]--><!--[if mso]>
+  <xml>
+  <o:OfficeDocumentSettings>
+    <o:AllowPNG/>
+    <o:PixelsPerInch>96</o:PixelsPerInch>
+  </o:OfficeDocumentSettings>
+  </xml>
+  <![endif]--><!--[if lte mso 11]>
+  <style type="text/css">
+    .outlook-group-fix { width:100% !important; }
+  </style>
+  <![endif]--><!--[if !mso]><!-->
+    <link href="https://fonts.googleapis.com/css?family=Ubuntu:300,400,500,700" rel="stylesheet" type="text/css">
+    <style type="text/css">
+        @import url(https://fonts.googleapis.com/css?family=Ubuntu:300,400,500,700);
+    </style><!--<![endif]-->
+    <style type="text/css">
+        @media only screen and (min-width:480px) {
+            .mj-column-per-100 {
+                width: 100% !important;
+                max-width: 100%;
+            }
+        }
+    </style>
+    <style type="text/css"></style>
+</head>
+
+<body style="background-color:#fafbfc;">
+    <div style="background-color:#fafbfc;">
+        <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" class="" style="width:600px;" width="600" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+        <div style="background:#ffffff;background-color:#ffffff;Margin:0px auto;max-width:600px;">
+            <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation"
+                style="background:#ffffff;background-color:#ffffff;width:100%;">
+                <tbody>
+                    <tr>
+                        <td style="direction:ltr;font-size:0px;padding:40px 20px;text-align:center;vertical-align:top;">
+                            <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" style="vertical-align:middle;width:560px;" ><![endif]-->
+                            <div class="mj-column-per-100 outlook-group-fix"
+                                style="font-size:13px;text-align:left;direction:ltr;display:inline-block;vertical-align:middle;width:100%;">
+                                <table border="0" cellpadding="0" cellspacing="0" role="presentation"
+                                    style="vertical-align:middle;" width="100%">
+                                    <tr>
+                                        <td align="center" style="font-size:0px;padding:35px;word-break:break-word;">
+                                            <div
+                                                style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:20px;line-height:1;text-align:center;color:#333333;">
+                                                {{ project_name }} - New Account</div>
+                                        </td>
+                                    </tr>
+                                    <tr>
+                                        <td align="center"
+                                            style="font-size:0px;padding:10px 25px;padding-right:25px;padding-left:25px;word-break:break-word;">
+                                            <div
+                                                style="font-family:Arial, Helvetica, sans-serif;font-size:16px;line-height:1;text-align:center;color:#555555;">
+                                                <span>Welcome to your new account!</span></div>
+                                        </td>
+                                    </tr>
+                                    <tr>
+                                        <td align="center"
+                                            style="font-size:0px;padding:10px 25px;padding-right:25px;padding-left:25px;word-break:break-word;">
+                                            <div
+                                                style="font-family:Arial, Helvetica, sans-serif;font-size:16px;line-height:1;text-align:center;color:#555555;">
+                                                Here are your account details:</div>
+                                        </td>
+                                    </tr>
+                                    <tr>
+                                        <td align="center"
+                                            style="font-size:0px;padding:10px 25px;padding-right:25px;padding-left:25px;word-break:break-word;">
+                                            <div
+                                                style="font-family:Arial, Helvetica, sans-serif;font-size:16px;line-height:1;text-align:center;color:#555555;">
+                                                Username: {{ username }}</div>
+                                        </td>
+                                    </tr>
+                                    <tr>
+                                        <td align="center"
+                                            style="font-size:0px;padding:10px 25px;padding-right:25px;padding-left:25px;word-break:break-word;">
+                                            <div
+                                                style="font-family:Arial, Helvetica, sans-serif;font-size:16px;line-height:1;text-align:center;color:#555555;">
+                                                Password: {{ password }}</div>
+                                        </td>
+                                    </tr>
+                                    <tr>
+                                        <td align="center" vertical-align="middle"
+                                            style="font-size:0px;padding:15px 30px;word-break:break-word;">
+                                            <table border="0" cellpadding="0" cellspacing="0" role="presentation"
+                                                style="border-collapse:separate;line-height:100%;">
+                                                <tr>
+                                                    <td align="center" bgcolor="#009688" role="presentation"
+                                                        style="border:none;border-radius:8px;cursor:auto;padding:10px 25px;background:#009688;"
+                                                        valign="middle"><a href="{{ link }}"
+                                                            style="background:#009688;color:#ffffff;font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:18px;font-weight:normal;line-height:120%;Margin:0;text-decoration:none;text-transform:none;"
+                                                            target="_blank">Go to Dashboard</a></td>
+                                                </tr>
+                                            </table>
+                                        </td>
+                                    </tr>
+                                    <tr>
+                                        <td style="font-size:0px;padding:10px 25px;word-break:break-word;">
+                                            <p
+                                                style="border-top:solid 2px #cccccc;font-size:1;margin:0px auto;width:100%;">
+                                            </p><!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" style="border-top:solid 2px #cccccc;font-size:1;margin:0px auto;width:510px;" role="presentation" width="510px" ><tr><td style="height:0;line-height:0;"> &nbsp;
+</td></tr></table><![endif]-->
+                                        </td>
+                                    </tr>
+                                </table>
+                            </div><!--[if mso | IE]></td></tr></table><![endif]-->
+                        </td>
+                    </tr>
+                </tbody>
+            </table>
+        </div><!--[if mso | IE]></td></tr></table><![endif]-->
+    </div>
+</body>
+
+</html>

--- a/backend/app/email-templates/html/reset_password.html
+++ b/backend/app/email-templates/html/reset_password.html
@@ -1,0 +1,196 @@
+<!doctype html>
+<html xmlns="http://www.w3.org/1999/xhtml" xmlns:v="urn:schemas-microsoft-com:vml"
+    xmlns:o="urn:schemas-microsoft-com:office:office">
+
+<head>
+    <title></title><!--[if !mso]><!-- -->
+    <meta http-equiv="X-UA-Compatible" content="IE=edge"><!--<![endif]-->
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+    <meta name="viewport" content="width=device-width,initial-scale=1">
+    <style type="text/css">
+        #outlook a {
+            padding: 0;
+        }
+
+        .ReadMsgBody {
+            width: 100%;
+        }
+
+        .ExternalClass {
+            width: 100%;
+        }
+
+        .ExternalClass * {
+            line-height: 100%;
+        }
+
+        body {
+            margin: 0;
+            padding: 0;
+            -webkit-text-size-adjust: 100%;
+            -ms-text-size-adjust: 100%;
+        }
+
+        table,
+        td {
+            border-collapse: collapse;
+            mso-table-lspace: 0pt;
+            mso-table-rspace: 0pt;
+        }
+
+        img {
+            border: 0;
+            height: auto;
+            line-height: 100%;
+            outline: none;
+            text-decoration: none;
+            -ms-interpolation-mode: bicubic;
+        }
+
+        p {
+            display: block;
+            margin: 13px 0;
+        }
+    </style><!--[if !mso]><!-->
+    <style type="text/css">
+        @media only screen and (max-width:480px) {
+            @-ms-viewport {
+                width: 320px;
+            }
+
+            @viewport {
+                width: 320px;
+            }
+        }
+    </style><!--<![endif]--><!--[if mso]>
+  <xml>
+  <o:OfficeDocumentSettings>
+    <o:AllowPNG/>
+    <o:PixelsPerInch>96</o:PixelsPerInch>
+  </o:OfficeDocumentSettings>
+  </xml>
+  <![endif]--><!--[if lte mso 11]>
+  <style type="text/css">
+    .outlook-group-fix { width:100% !important; }
+  </style>
+  <![endif]--><!--[if !mso]><!-->
+    <link href="https://fonts.googleapis.com/css?family=Ubuntu:300,400,500,700" rel="stylesheet" type="text/css">
+    <style type="text/css">
+        @import url(https://fonts.googleapis.com/css?family=Ubuntu:300,400,500,700);
+    </style><!--<![endif]-->
+    <style type="text/css">
+        @media only screen and (min-width:480px) {
+            .mj-column-per-100 {
+                width: 100% !important;
+                max-width: 100%;
+            }
+        }
+    </style>
+    <style type="text/css"></style>
+</head>
+
+<body style="background-color:#fafbfc;">
+    <div style="background-color:#fafbfc;">
+        <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" class="" style="width:600px;" width="600" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+        <div style="background:#ffffff;background-color:#ffffff;Margin:0px auto;max-width:600px;">
+            <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation"
+                style="background:#ffffff;background-color:#ffffff;width:100%;">
+                <tbody>
+                    <tr>
+                        <td style="direction:ltr;font-size:0px;padding:40px 20px;text-align:center;vertical-align:top;">
+                            <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" style="vertical-align:middle;width:560px;" ><![endif]-->
+                            <div class="mj-column-per-100 outlook-group-fix"
+                                style="font-size:13px;text-align:left;direction:ltr;display:inline-block;vertical-align:middle;width:100%;">
+                                <table border="0" cellpadding="0" cellspacing="0" role="presentation"
+                                    style="vertical-align:middle;" width="100%">
+                                    <tr>
+                                        <td align="center" style="font-size:0px;padding:35px;word-break:break-word;">
+                                            <div
+                                                style="font-family:Arial, Helvetica, sans-serif;font-size:20px;line-height:1;text-align:center;color:#333333;">
+                                                {{ project_name }} - Password Recovery</div>
+                                        </td>
+                                    </tr>
+                                    <tr>
+                                        <td align="center"
+                                            style="font-size:0px;padding:10px 25px;padding-right:25px;padding-left:25px;word-break:break-word;">
+                                            <div
+                                                style="font-family:Arial, Helvetica, sans-serif;font-size:16px;line-height:1;text-align:center;color:#555555;">
+                                                <span>Hello {{ username }}</span></div>
+                                        </td>
+                                    </tr>
+                                    <tr>
+                                        <td align="center"
+                                            style="font-size:0px;padding:10px 25px;padding-right:25px;padding-left:25px;word-break:break-word;">
+                                            <div
+                                                style="font-family:Arial, Helvetica, sans-serif;font-size:16px;line-height:1;text-align:center;color:#555555;">
+                                                We've received a request to reset your password. You can do it by
+                                                clicking the button below:</div>
+                                        </td>
+                                    </tr>
+                                    <tr>
+                                        <td align="center" vertical-align="middle"
+                                            style="font-size:0px;padding:15px 30px;word-break:break-word;">
+                                            <table border="0" cellpadding="0" cellspacing="0" role="presentation"
+                                                style="border-collapse:separate;line-height:100%;">
+                                                <tr>
+                                                    <td align="center" bgcolor="#009688" role="presentation"
+                                                        style="border:none;border-radius:8px;cursor:auto;padding:10px 25px;background:#009688;"
+                                                        valign="middle"><a href="{{ link }}"
+                                                            style="background:#009688;color:#ffffff;font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:18px;font-weight:normal;line-height:120%;Margin:0;text-decoration:none;text-transform:none;"
+                                                            target="_blank">Reset password</a></td>
+                                                </tr>
+                                            </table>
+                                        </td>
+                                    </tr>
+                                    <tr>
+                                        <td align="center"
+                                            style="font-size:0px;padding:10px 25px;padding-right:25px;padding-left:25px;word-break:break-word;">
+                                            <div
+                                                style="font-family:Arial, Helvetica, sans-serif;font-size:16px;line-height:1;text-align:center;color:#555555;">
+                                                Or copy and paste the following link into your browser:</div>
+                                        </td>
+                                    </tr>
+                                    <tr>
+                                        <td align="center"
+                                            style="font-size:0px;padding:10px 25px;padding-right:25px;padding-left:25px;word-break:break-word;">
+                                            <div
+                                                style="font-family:Arial, Helvetica, sans-serif;font-size:16px;line-height:1;text-align:center;color:#555555;">
+                                                <a href="{{ link }}">{{ link }}</a></div>
+                                        </td>
+                                    </tr>
+                                    <tr>
+                                        <td align="center"
+                                            style="font-size:0px;padding:10px 25px;padding-right:25px;padding-left:25px;word-break:break-word;">
+                                            <div
+                                                style="font-family:Arial, Helvetica, sans-serif;font-size:16px;line-height:1;text-align:center;color:#555555;">
+                                                This password will expire in {{ valid_hours }} hours.</div>
+                                        </td>
+                                    </tr>
+                                    <tr>
+                                        <td style="font-size:0px;padding:10px 25px;word-break:break-word;">
+                                            <p
+                                                style="border-top:solid 2px #cccccc;font-size:1;margin:0px auto;width:100%;">
+                                            </p><!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" style="border-top:solid 2px #cccccc;font-size:1;margin:0px auto;width:510px;" role="presentation" width="510px" ><tr><td style="height:0;line-height:0;"> &nbsp;
+</td></tr></table><![endif]-->
+                                        </td>
+                                    </tr>
+                                    <tr>
+                                        <td align="center"
+                                            style="font-size:0px;padding:10px 25px;padding-right:25px;padding-left:25px;word-break:break-word;">
+                                            <div
+                                                style="font-family:Arial, Helvetica, sans-serif;font-size:14px;line-height:1;text-align:center;color:#555555;">
+                                                If you didn't request a password recovery you can disregard this email.
+                                            </div>
+                                        </td>
+                                    </tr>
+                                </table>
+                            </div><!--[if mso | IE]></td></tr></table><![endif]-->
+                        </td>
+                    </tr>
+                </tbody>
+            </table>
+        </div><!--[if mso | IE]></td></tr></table><![endif]-->
+    </div>
+</body>
+
+</html>

--- a/backend/app/email-templates/html/test_email.html
+++ b/backend/app/email-templates/html/test_email.html
@@ -1,0 +1,178 @@
+<!doctype html>
+<html xmlns="http://www.w3.org/1999/xhtml" xmlns:v="urn:schemas-microsoft-com:vml"
+    xmlns:o="urn:schemas-microsoft-com:office:office">
+
+<head>
+    <title></title><!--[if !mso]><!-- -->
+    <meta http-equiv="X-UA-Compatible" content="IE=edge"><!--<![endif]-->
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+    <meta name="viewport" content="width=device-width,initial-scale=1">
+    <style type="text/css">
+        #outlook a {
+            padding: 0;
+        }
+
+        .ReadMsgBody {
+            width: 100%;
+        }
+
+        .ExternalClass {
+            width: 100%;
+        }
+
+        .ExternalClass * {
+            line-height: 100%;
+        }
+
+        body {
+            margin: 0;
+            padding: 0;
+            -webkit-text-size-adjust: 100%;
+            -ms-text-size-adjust: 100%;
+        }
+
+        table,
+        td {
+            border-collapse: collapse;
+            mso-table-lspace: 0pt;
+            mso-table-rspace: 0pt;
+        }
+
+        img {
+            border: 0;
+            height: auto;
+            line-height: 100%;
+            outline: none;
+            text-decoration: none;
+            -ms-interpolation-mode: bicubic;
+        }
+
+        p {
+            display: block;
+            margin: 13px 0;
+        }
+    </style><!--[if !mso]><!-->
+    <style type="text/css">
+        @media only screen and (max-width:480px) {
+            @-ms-viewport {
+                width: 320px;
+            }
+
+            @viewport {
+                width: 320px;
+            }
+        }
+    </style><!--<![endif]--><!--[if mso]>
+  <xml>
+  <o:OfficeDocumentSettings>
+    <o:AllowPNG/>
+    <o:PixelsPerInch>96</o:PixelsPerInch>
+  </o:OfficeDocumentSettings>
+  </xml>
+  <![endif]--><!--[if lte mso 11]>
+  <style type="text/css">
+    .outlook-group-fix { width:100% !important; }
+  </style>
+  <![endif]--><!--[if !mso]><!-->
+    <link href="https://fonts.googleapis.com/css?family=Ubuntu:300,400,500,700" rel="stylesheet" type="text/css">
+    <style type="text/css">
+        @import url(https://fonts.googleapis.com/css?family=Ubuntu:300,400,500,700);
+    </style><!--<![endif]-->
+    <style type="text/css">
+        @media only screen and (min-width:480px) {
+            .mj-column-per-100 {
+                width: 100% !important;
+                max-width: 100%;
+            }
+        }
+    </style>
+    <style type="text/css"></style>
+</head>
+
+<body style="background-color:#fafbfc;">
+    <div style="background-color:#fafbfc;">
+        <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" class="" style="width:600px;" width="600" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+        <div style="background:#ffffff;background-color:#ffffff;Margin:0px auto;max-width:600px;">
+            <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation"
+                style="background:#ffffff;background-color:#ffffff;width:100%;">
+                <tbody>
+                    <tr>
+                        <td style="direction:ltr;font-size:0px;padding:40px 20px;text-align:center;vertical-align:top;">
+                            <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" style="vertical-align:middle;width:560px;" ><![endif]-->
+                            <div class="mj-column-per-100 outlook-group-fix"
+                                style="font-size:13px;text-align:left;direction:ltr;display:inline-block;vertical-align:middle;width:100%;">
+                                <table border="0" cellpadding="0" cellspacing="0" role="presentation"
+                                    style="vertical-align:middle;" width="100%">
+                                    <tr>
+                                        <td align="center" style="font-size:0px;padding:35px;word-break:break-word;">
+                                            <div
+                                                style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:20px;line-height:1;text-align:center;color:#333333;">
+                                                {{ project_name }} - New Account</div>
+                                        </td>
+                                    </tr>
+                                    <tr>
+                                        <td align="center"
+                                            style="font-size:0px;padding:10px 25px;padding-right:25px;padding-left:25px;word-break:break-word;">
+                                            <div
+                                                style="font-family:Arial, Helvetica, sans-serif;font-size:16px;line-height:1;text-align:center;color:#555555;">
+                                                <span>Welcome to your new account!</span></div>
+                                        </td>
+                                    </tr>
+                                    <tr>
+                                        <td align="center"
+                                            style="font-size:0px;padding:10px 25px;padding-right:25px;padding-left:25px;word-break:break-word;">
+                                            <div
+                                                style="font-family:Arial, Helvetica, sans-serif;font-size:16px;line-height:1;text-align:center;color:#555555;">
+                                                Here are your account details:</div>
+                                        </td>
+                                    </tr>
+                                    <tr>
+                                        <td align="center"
+                                            style="font-size:0px;padding:10px 25px;padding-right:25px;padding-left:25px;word-break:break-word;">
+                                            <div
+                                                style="font-family:Arial, Helvetica, sans-serif;font-size:16px;line-height:1;text-align:center;color:#555555;">
+                                                Username: {{ username }}</div>
+                                        </td>
+                                    </tr>
+                                    <tr>
+                                        <td align="center"
+                                            style="font-size:0px;padding:10px 25px;padding-right:25px;padding-left:25px;word-break:break-word;">
+                                            <div
+                                                style="font-family:Arial, Helvetica, sans-serif;font-size:16px;line-height:1;text-align:center;color:#555555;">
+                                                Password: {{ password }}</div>
+                                        </td>
+                                    </tr>
+                                    <tr>
+                                        <td align="center" vertical-align="middle"
+                                            style="font-size:0px;padding:15px 30px;word-break:break-word;">
+                                            <table border="0" cellpadding="0" cellspacing="0" role="presentation"
+                                                style="border-collapse:separate;line-height:100%;">
+                                                <tr>
+                                                    <td align="center" bgcolor="#009688" role="presentation"
+                                                        style="border:none;border-radius:8px;cursor:auto;padding:10px 25px;background:#009688;"
+                                                        valign="middle"><a href="{{ link }}"
+                                                            style="background:#009688;color:#ffffff;font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:18px;font-weight:normal;line-height:120%;Margin:0;text-decoration:none;text-transform:none;"
+                                                            target="_blank">Go to Dashboard</a></td>
+                                                </tr>
+                                            </table>
+                                        </td>
+                                    </tr>
+                                    <tr>
+                                        <td style="font-size:0px;padding:10px 25px;word-break:break-word;">
+                                            <p
+                                                style="border-top:solid 2px #cccccc;font-size:1;margin:0px auto;width:100%;">
+                                            </p><!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" style="border-top:solid 2px #cccccc;font-size:1;margin:0px auto;width:510px;" role="presentation" width="510px" ><tr><td style="height:0;line-height:0;"> &nbsp;
+</td></tr></table><![endif]-->
+                                        </td>
+                                    </tr>
+                                </table>
+                            </div><!--[if mso | IE]></td></tr></table><![endif]-->
+                        </td>
+                    </tr>
+                </tbody>
+            </table>
+        </div><!--[if mso | IE]></td></tr></table><![endif]-->
+    </div>
+</body>
+
+</html>

--- a/backend/app/utils/utils.py
+++ b/backend/app/utils/utils.py
@@ -20,7 +20,7 @@ class EmailData:
 
 def render_email_template(*, template_name: str, context: dict[str, Any]) -> str:
     base_dir = Path(__file__).resolve().parent.parent  # This goes from utils.py up to app/
-    template_path = base_dir / "email-templates" / "build" / template_name
+    template_path = base_dir / "email-templates" / "html" / template_name
     template_str = template_path.read_text()
     html_content = Template(template_str).render(context)
     return html_content


### PR DESCRIPTION
In previous commits email-templates/build folder was missing because build folder is added in the .gitignore
Now, it's renamed to email-templates/html and contains all html files which will be sent to the emails.